### PR TITLE
IftU: fix the line about directions in RU

### DIFF
--- a/Invasion_from_the_Unknown/ru.po
+++ b/Invasion_from_the_Unknown/ru.po
@@ -3265,7 +3265,6 @@ msgstr "Что делают те существа?"
 
 #. [message]: speaker=Durcanos
 #: Invasion_from_the_Unknown/scenarios/13_Face_your_Fate.cfg:339
-#, fuzzy
 msgid ""
 "I’m na’ sure, they seem to be laying larvae on the flooded western keep."
 msgstr "Похоже, они откладывают личинки в затопленной крепости на западе."


### PR DESCRIPTION
It was already translated to 'western' before I told about it, so I just removed the `fuzzy` blocker.